### PR TITLE
Fix noclip persistence, networking stability, and dynamic permission syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This mod also adds:
 
 ---
 
+### **Requirements**
+- **Fabric API 0.133.0 or newer**
+
+---
+
 ### [**CurseForge**](https://curseforge.com/minecraft/mc-mods/noclip) | [**Modrinth**](https://modrinth.com/mod/noclip)
 
 ---

--- a/src/client/java/dev/andante/noclip/impl/client/NoClipManagerImpl.java
+++ b/src/client/java/dev/andante/noclip/impl/client/NoClipManagerImpl.java
@@ -35,7 +35,8 @@ public final class NoClipManagerImpl implements NoClipManager {
     @Override
     public void setCanClip(boolean canClip) {
         this.canClip = canClip;
-        if (!this.canClip) this.updateClipping();
+        if (!this.canClip)
+            this.updateClipping();
     }
 
     @Override
@@ -67,10 +68,11 @@ public final class NoClipManagerImpl implements NoClipManager {
             boolean clipping = packet.clipping();
 
             clipManager.setClipping(clipping);
-            if (NoClipKeyBindings.ACTIVATE_NOCLIP.isPressed() != clipping) NoClipKeyBindings.ACTIVATE_NOCLIP.setPressed(true);
+            if (NoClipKeyBindings.ACTIVATE_NOCLIP.isPressed() != clipping)
+                NoClipKeyBindings.ACTIVATE_NOCLIP.setPressed(clipping);
         }
 
-        clipManager.updateClipping();
+        clipManager.updateClipping(false);
     }
 
     /**

--- a/src/client/java/dev/andante/noclip/impl/client/keybinding/NoClipKeyBindingsImpl.java
+++ b/src/client/java/dev/andante/noclip/impl/client/keybinding/NoClipKeyBindingsImpl.java
@@ -31,7 +31,8 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
 
     public static void onEndClientTick(MinecraftClient client) {
         ClientPlayerEntity player = client.player;
-        if (player == null) return;
+        if (player == null)
+            return;
 
         NoClipConfig config = NoClipClient.getConfig();
         NoClipConfig.Flight flightConfig = config.flight;
@@ -43,7 +44,18 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
         if (clipping.canClip()) {
             GameMode mode = client.interactionManager.getCurrentGameMode();
             boolean prev = clipping.isClipping();
-            boolean curr = ACTIVATE_NOCLIP.isPressed() && allowedModes.contains(mode);
+            boolean curr = prev;
+
+            if (config.keyBehaviors.noClip == KeyBehavior.TOGGLE) {
+                while (ACTIVATE_NOCLIP.wasPressed()) {
+                    curr = !curr;
+                }
+            } else {
+                curr = ACTIVATE_NOCLIP.isPressed();
+            }
+
+            curr &= allowedModes.contains(mode);
+
             if (prev != curr) {
                 clipping.setClipping(curr);
                 clipping.updateClipping();
@@ -72,7 +84,8 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
         /* Snappy Flight */
 
         if (abilities.flying) {
-            if (flightConfig.snappyFlight.enabled && (!flightConfig.snappyFlight.onlyInNoClip || clipping.isClipping())) {
+            if (flightConfig.snappyFlight.enabled
+                    && (!flightConfig.snappyFlight.onlyInNoClip || clipping.isClipping())) {
                 player.setVelocity(Vec3d.ZERO);
 
                 int sideways = 0;
@@ -80,12 +93,18 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
                 int forward = 0;
 
                 GameOptions options = client.options;
-                if (options.leftKey.isPressed()) sideways += 1;
-                if (options.rightKey.isPressed()) sideways -= 1;
-                if (options.jumpKey.isPressed()) upward += 1;
-                if (options.sneakKey.isPressed()) upward -= 1;
-                if (options.forwardKey.isPressed()) forward += 1;
-                if (options.backKey.isPressed()) forward -= 1;
+                if (options.leftKey.isPressed())
+                    sideways += 1;
+                if (options.rightKey.isPressed())
+                    sideways -= 1;
+                if (options.jumpKey.isPressed())
+                    upward += 1;
+                if (options.sneakKey.isPressed())
+                    upward -= 1;
+                if (options.forwardKey.isPressed())
+                    forward += 1;
+                if (options.backKey.isPressed())
+                    forward -= 1;
 
                 player.travel(new Vec3d(sideways, upward, forward));
                 player.setVelocity(player.getVelocity().multiply(7.0D));
@@ -98,7 +117,8 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
         if (RESET_FLIGHT_SPEED.wasPressed()) {
             PlayerAbilities def = new PlayerAbilities();
             abilities.setFlySpeed(def.getFlySpeed());
-            player.sendMessage(Text.translatable(RESET_FLIGHT_SPEED_KEY, 1.0f).setStyle(NoClipClient.getTextStyle()), true);
+            player.sendMessage(Text.translatable(RESET_FLIGHT_SPEED_KEY, 1.0f).setStyle(NoClipClient.getTextStyle()),
+                    true);
         }
     }
 
@@ -109,10 +129,14 @@ public final class NoClipKeyBindingsImpl implements NoClipKeyBindings {
 
     private static List<GameMode> createAllowedModes(AllowIn allow) {
         List<GameMode> list = new ArrayList<>();
-        if (allow.creative) list.add(GameMode.CREATIVE);
-        if (allow.survival) list.add(GameMode.SURVIVAL);
-        if (allow.adventure) list.add(GameMode.ADVENTURE);
-        if (allow.spectator) list.add(GameMode.SPECTATOR);
+        if (allow.creative)
+            list.add(GameMode.CREATIVE);
+        if (allow.survival)
+            list.add(GameMode.SURVIVAL);
+        if (allow.adventure)
+            list.add(GameMode.ADVENTURE);
+        if (allow.spectator)
+            list.add(GameMode.SPECTATOR);
         return list;
     }
 }

--- a/src/main/java/dev/andante/noclip/impl/ClippingEntity.java
+++ b/src/main/java/dev/andante/noclip/impl/ClippingEntity.java
@@ -4,7 +4,10 @@ public interface ClippingEntity {
     boolean canClip();
 
     boolean isClipping();
+
     void setClipping(boolean clipping);
+
+    void setLastCanClip(boolean lastCanClip);
 
     boolean isClippingInsideWall();
 

--- a/src/main/java/dev/andante/noclip/impl/NoClipImpl.java
+++ b/src/main/java/dev/andante/noclip/impl/NoClipImpl.java
@@ -34,7 +34,9 @@ public final class NoClipImpl implements NoClip, ModInitializer {
      */
     private void onPlayerJoin(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {
         ClippingEntity clippingPlayer = ClippingEntity.cast(handler.player);
-        ServerPlayNetworking.send(handler.player, new ClippingUpdatePacket(clippingPlayer.isClipping(), clippingPlayer.canClip()));
+        boolean canClip = clippingPlayer.canClip();
+        clippingPlayer.setLastCanClip(canClip);
+        ServerPlayNetworking.send(handler.player, new ClippingUpdatePacket(clippingPlayer.isClipping(), canClip));
     }
 
     /**
@@ -42,12 +44,24 @@ public final class NoClipImpl implements NoClip, ModInitializer {
      */
     private void receiveUpdate(ClippingUpdatePacket packet, ServerPlayNetworking.Context context) {
         ServerPlayerEntity player = context.player();
-        boolean clipping = packet.clipping();
         ClippingEntity clippingPlayer = ClippingEntity.cast(player);
+
+        if (!clippingPlayer.canClip()) {
+            clippingPlayer.setClipping(false);
+            ServerPlayNetworking.send(player, new ClippingUpdatePacket(false, false));
+
+            GameMode mode = player.interactionManager.getGameMode();
+            mode.setAbilities(player.getAbilities());
+            player.sendAbilitiesUpdate();
+            return;
+        }
+
+        boolean clipping = packet.clipping();
         clippingPlayer.setClipping(clipping);
 
         GameMode mode = player.interactionManager.getGameMode();
         mode.setAbilities(player.getAbilities());
+        player.sendAbilitiesUpdate();
     }
 
     /**
@@ -62,8 +76,7 @@ public final class NoClipImpl implements NoClip, ModInitializer {
     private void afterRespawn(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer, boolean alive) {
         ClippingEntity clippingNewPlayer = ClippingEntity.cast(newPlayer);
         if (clippingNewPlayer.isClipping()) {
-            ServerPlayNetworking.send(newPlayer, new ClippingUpdatePacket(false, false));
-            ServerPlayNetworking.send(newPlayer, new ClippingUpdatePacket(true, true));
+            ServerPlayNetworking.send(newPlayer, new ClippingUpdatePacket(true, clippingNewPlayer.canClip()));
         }
     }
 }

--- a/src/main/java/dev/andante/noclip/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/andante/noclip/mixin/PlayerEntityMixin.java
@@ -5,8 +5,10 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mojang.authlib.GameProfile;
 import dev.andante.noclip.api.NoClip;
 import dev.andante.noclip.impl.ClippingEntity;
+import dev.andante.noclip.impl.ClippingUpdatePacket;
 import dev.andante.noclip.impl.PlayerAbilitiesAccess;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
@@ -15,9 +17,11 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerAbilities;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.storage.ReadView;
 import net.minecraft.storage.WriteView;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -32,8 +36,13 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @SuppressWarnings("InvalidInjectorMethodSignature")
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin extends LivingEntity implements ClippingEntity {
-    @Shadow @Final private PlayerAbilities abilities;
-    @Unique private boolean clipping;
+    @Shadow
+    @Final
+    private PlayerAbilities abilities;
+    @Unique
+    private boolean clipping;
+    @Unique
+    private boolean lastCanClip;
 
     private PlayerEntityMixin(EntityType<? extends LivingEntity> type, World world) {
         super(type, world);
@@ -60,8 +69,15 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Clipping
 
     @Unique
     @Override
+    public void setLastCanClip(boolean lastCanClip) {
+        this.lastCanClip = lastCanClip;
+    }
+
+    @Unique
+    @Override
     public boolean isClippingInsideWall() {
-        if (!this.isClipping()) return false;
+        if (!this.isClipping())
+            return false;
 
         // love this.
         this.noClip = false;
@@ -82,15 +98,31 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Clipping
     /**
      * Updates the player's clipping value based on our custom parameters.
      */
-    @Inject(
-        method = "tick",
-        at = @At(
-            value = "FIELD",
-            target = "Lnet/minecraft/entity/player/PlayerEntity;noClip:Z",
-            shift = At.Shift.AFTER
-        )
-    )
+    @Inject(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerEntity;noClip:Z", shift = At.Shift.AFTER))
     private void onTickAfterNoClip(CallbackInfo ci) {
+        if ((Object) this instanceof ServerPlayerEntity player) {
+            boolean canClip = this.canClip();
+            boolean forceSync = this.lastCanClip != canClip;
+
+            if (this.isClipping() && !canClip) {
+                this.setClipping(false);
+                forceSync = true;
+
+                GameMode mode = player.interactionManager.getGameMode();
+                mode.setAbilities(player.getAbilities());
+                player.sendAbilitiesUpdate();
+            }
+
+            if (forceSync) {
+                this.lastCanClip = canClip;
+                ServerPlayNetworking.send(player, new ClippingUpdatePacket(this.isClipping(), canClip));
+            }
+
+            if (this.isClipping() && !canClip) {
+                return;
+            }
+        }
+
         if (this.isClipping()) {
             this.noClip = true;
             this.setOnGround(false);
@@ -114,18 +146,10 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Clipping
     /**
      * Ignores ground checks for block breaking speed when clipping.
      */
-    @Inject(
-        method = "getBlockBreakingSpeed",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/entity/player/PlayerEntity;isSubmergedIn(Lnet/minecraft/registry/tag/TagKey;)Z",
-            shift = At.Shift.BEFORE
-        ),
-        locals = LocalCapture.CAPTURE_FAILHARD,
-        cancellable = true
-    )
+    @Inject(method = "getBlockBreakingSpeed", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isSubmergedIn(Lnet/minecraft/registry/tag/TagKey;)Z", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
     private void onGetBlockBreakingSpeed(BlockState block, CallbackInfoReturnable<Float> cir, float speed) {
-        if (this.isClipping()) cir.setReturnValue(speed);
+        if (this.isClipping())
+            cir.setReturnValue(speed);
     }
 
     /**


### PR DESCRIPTION
These changes increase the reliability of noclip state management, improve the user experience for toggling noclip, and make the codebase easier to maintain. #19 

**Server-client synchronization and clipping logic:**

* Improved synchronization of the player's ability to clip (`canClip`) and actual clipping state between server and client, including forced state updates when permissions change or after respawn. Added a `lastCanClip` field to track changes and ensure the client is updated when the ability to noclip changes. (`src/main/java/dev/andante/noclip/impl/NoClipImpl.java`, `src/main/java/dev/andante/noclip/impl/ClippingEntity.java`, `src/main/java/dev/andante/noclip/mixin/PlayerEntityMixin.java`) [[1]](diffhunk://#diff-85e944ae079fc623e7dabf1902169ee4211f7841863d06ea239ccfd1ba45e318L37-R64) [[2]](diffhunk://#diff-85e944ae079fc623e7dabf1902169ee4211f7841863d06ea239ccfd1ba45e318L65-R79) [[3]](diffhunk://#diff-1a3a9b18b7acd17b0bc58c276f66c59f2b93d0f29d812ba0a50356772d86656fR7-R11) [[4]](diffhunk://#diff-de4eb3541d4c38da3690ac9f9a26e932aae898530fd820d69d027ba8d1787112L35-R45) [[5]](diffhunk://#diff-de4eb3541d4c38da3690ac9f9a26e932aae898530fd820d69d027ba8d1787112R70-R80) [[6]](diffhunk://#diff-de4eb3541d4c38da3690ac9f9a26e932aae898530fd820d69d027ba8d1787112L85-R125)
* Ensured that when a player loses permission to noclip, their state and abilities are reset and the client is notified. (`src/main/java/dev/andante/noclip/impl/NoClipImpl.java`, `src/main/java/dev/andante/noclip/mixin/PlayerEntityMixin.java`) [[1]](diffhunk://#diff-85e944ae079fc623e7dabf1902169ee4211f7841863d06ea239ccfd1ba45e318L37-R64) [[2]](diffhunk://#diff-de4eb3541d4c38da3690ac9f9a26e932aae898530fd820d69d027ba8d1787112L85-R125)

**Keybinding and input handling:**

* Updated noclip activation logic to properly support toggle and hold behaviors, making the toggling of noclip mode more intuitive and reliable for users. (`src/client/java/dev/andante/noclip/impl/client/keybinding/NoClipKeyBindingsImpl.java`)
* Improved handling of key input checks and allowed game modes, and refactored code for clarity and maintainability. (`src/client/java/dev/andante/noclip/impl/client/keybinding/NoClipKeyBindingsImpl.java`) [[1]](diffhunk://#diff-95111d14fea4eb40ab70471b11358e4fe78ba3531dae5754a39eb5f79b1146d1L34-R35) [[2]](diffhunk://#diff-95111d14fea4eb40ab70471b11358e4fe78ba3531dae5754a39eb5f79b1146d1L112-R139)

**Code style and documentation:**

* Reformatted code to improve readability, such as expanding single-line conditionals and aligning method arguments. (`src/client/java/dev/andante/noclip/impl/client/keybinding/NoClipKeyBindingsImpl.java`, `src/client/java/dev/andante/noclip/impl/client/NoClipManagerImpl.java`) [[1]](diffhunk://#diff-95111d14fea4eb40ab70471b11358e4fe78ba3531dae5754a39eb5f79b1146d1L75-R107) [[2]](diffhunk://#diff-95111d14fea4eb40ab70471b11358e4fe78ba3531dae5754a39eb5f79b1146d1L101-R121) [[3]](diffhunk://#diff-658dde90dce74e1315e7b0762631a77a0c3b2aefc5b17daf901f95c43f1d23caL38-R39) [[4]](diffhunk://#diff-658dde90dce74e1315e7b0762631a77a0c3b2aefc5b17daf901f95c43f1d23caL70-R75)
* Updated the `README.md` to specify the minimal required Fabric API version.